### PR TITLE
Added a link to Galleon releases on the support page

### DIFF
--- a/support.html
+++ b/support.html
@@ -75,6 +75,8 @@
   <section id="hero">
     <section id="hero-before"></section>
     <div class="usertool">
+      <h4> Looking for the latest version of Galleon? Visit our <a href="https://github.com/Cryptonomic/Deployments/wiki/Galleon:-Releases">releases page on GitHub.</a>
+      </h4>
         <div class="container-fluid h-100">
             <div class="row content h-100">           
               <div class="col-xl-12 hidden-xs">


### PR DESCRIPTION
Currently, the alert banner on Galleon directs users to the Cryptonomic support page to download the latest version. There is no easy way to download from here. 

Adding a message at the top of the support page helps users who are stuck on earlier versions of Galleon easily find the new releases while we update the banner link for the upcoming release and fix the app store builds. 